### PR TITLE
Refactor quiz API usage to use environment configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,16 @@
             "styles": ["src/styles.scss"]
           },
           "configurations": {
-            "production": { "optimization": true, "outputHashing": "all" },
+            "production": {
+              "optimization": true,
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
+            },
             "development": { "optimization": false, "sourceMap": true, "extractLicenses": false }
           },
           "defaultConfiguration": "development"

--- a/src/app/components/quiz-list/quiz-list.component.ts
+++ b/src/app/components/quiz-list/quiz-list.component.ts
@@ -3,10 +3,11 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Subject, takeUntil } from 'rxjs';
 import { QuestaoDTO, RespostaQuizDTO, ResultadoQuizDTO, RespostaDetalhada } from '../../models';
 import { SessionService } from '../../services/session.service';
+import { QuizService } from '../../services/quiz.service';
 
 @Component({
   selector: 'quiz-list',
@@ -29,13 +30,11 @@ export class QuizListComponent implements OnInit, OnDestroy {
   erro = '';
   isAnswered = false;
 
-  private readonly API_BASE = 'http://localhost:8080/api/quiz';
-
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    private http: HttpClient,
-    private sessionService: SessionService
+    private sessionService: SessionService,
+    private quizService: QuizService
   ) {}
 
   ngOnInit() {
@@ -67,9 +66,7 @@ export class QuizListComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.erro = '';
 
-    const url = `${this.API_BASE}/levels/${this.level}/questions`;
-
-    this.http.get<QuestaoDTO[]>(url).subscribe({
+    this.quizService.getQuestoesPorNivel(this.level).subscribe({
       next: (questoes) => {
         if (!questoes || questoes.length === 0) {
           this.erro = `Nível ${this.level} não possui perguntas disponíveis.`;
@@ -194,7 +191,7 @@ export class QuizListComponent implements OnInit, OnDestroy {
   submitQuiz() {
     this.loading = true;
 
-    this.http.post<ResultadoQuizDTO>(`${this.API_BASE}/respostas`, this.respostas).subscribe({
+    this.quizService.submitRespostas(this.respostas).subscribe({
       next: (resultado) => {
         console.log(`Resultado recebido:`, resultado);
 

--- a/src/app/services/quiz.service.ts
+++ b/src/app/services/quiz.service.ts
@@ -8,10 +8,11 @@ import {
   RespostaQuizDTO,
   ResultadoQuizDTO
 } from '../models';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class QuizService {
-  private baseUrl = '/api/quiz';
+  private readonly baseUrl = `${environment.apiBase}/quiz`;
 
   constructor(private http: HttpClient) {}
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBase: 'http://localhost:8080/api'
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBase: 'http://localhost:8080/api'
+};


### PR DESCRIPTION
## Summary
- add Angular environment files exposing an apiBase value and wire up production file replacement
- update QuizService to build API URLs from the shared base
- refactor QuizListComponent to consume QuizService instead of HttpClient directly

## Testing
- npm run build *(fails: ng command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9824e53c48321b68ac9169b8737a9