### PR TITLE
Update quiz service spec to inject QuizService

### DIFF
--- a/src/app/services/quiz.spec.ts
+++ b/src/app/services/quiz.spec.ts
@@ -1,13 +1,15 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { QuizService } from './quiz.service';
 
-import { Quiz } from './quiz';
-
-describe('Quiz', () => {
-  let service: Quiz;
+describe('QuizService', () => {
+  let service: QuizService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(Quiz);
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
+    service = TestBed.inject(QuizService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- replace quiz spec to test QuizService instead of the old Quiz type
- configure TestBed with HttpClientTestingModule to satisfy QuizService dependencies

## Testing
- npm install *(fails: dependency conflict between @angular/compiler and @angular/compiler-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c98243ffd483218c108f7d5bd200fd