### PR TITLE
Adjust soon flag to include level 4

### DIFF
--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -174,7 +174,7 @@ public getNiveisComStatus() {
       tentativas: progressoNivel?.tentativas || 0,
       dataCompletado: progressoNivel?.dataCompletado,
       // ✅ ALTERAR ESTA LINHA: apenas níveis 4-5 ficam "em breve"
-      emBreve: config.numero > 5  // ← Era "false", agora só níveis 4+ são "em breve"
+      emBreve: config.numero >= 4  // ← Era "false", agora só níveis 4+ são "em breve"
     };
   });
 }


### PR DESCRIPTION
## Summary
- update the `emBreve` flag so only levels 4 and 5 remain marked as coming soon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9822692a483218c485b40ff3faafa